### PR TITLE
3.2 - Solución endpoint paginación

### DIFF
--- a/src/imc/repositories/CalculoImc.repository.ts
+++ b/src/imc/repositories/CalculoImc.repository.ts
@@ -62,7 +62,7 @@ export class CalculoImcRepository implements ICalculoImcRepository {
           .skip(skip)
           .limit(mostrar)
           .exec(),
-        this.imcModel.countDocuments({ userId }).exec(),
+        this.imcModel.countDocuments({ user: userId }).exec(),
       ]);
 
       return { data, total };


### PR DESCRIPTION
El endpoint de paginación mostraba '0' como el total siempre. El error era que en la base de datos se consultaba por el atributo userId, cuando en la base se guarda el atributo user para la id